### PR TITLE
Fix typos to make the copy & paste experience more smooth

### DIFF
--- a/docs/demos/podman-ai-lab-to-rhoai/podman-ai-lab-to-rhoai.md
+++ b/docs/demos/podman-ai-lab-to-rhoai/podman-ai-lab-to-rhoai.md
@@ -188,7 +188,7 @@ Now that the Elasticsearch operator has been deployed and an instance created, w
     
     **Note:** *If you have insufficient resources to start a medium container size then stop the workbench and change the workbench to start as a small container size.*
 
-7. Upload or import the ./notebooks/Langchain-ElasticSearchVector-ingest.ipynb notebook to your workbench.
+7. Upload or import the ./notebooks/Langchain-ElasticSearchVector-Ingest.ipynb notebook to your workbench.
 
     ![RHOAI Workbench Notebook](img/vector_ingest_notebook_upload.png)
 

--- a/docs/tools-and-applications/apache-spark/apache-spark.md
+++ b/docs/tools-and-applications/apache-spark/apache-spark.md
@@ -19,5 +19,5 @@ It includes:
 - instructions to deploy the Spark history server to gather your processing logs,
 - instructions to deploy the Spark on Kubernetes operator,
 - Prometheus and Grafana configuration to monitor your data processing and operator in real time,
-- instructions to work without the operator, from a Notebook or a Terminal, inside or outside the OpenShit Cluster,
+- instructions to work without the operator, from a Notebook or a Terminal, inside or outside the OpenShift Cluster,
 - various examples to test your installation and the different methods.


### PR DESCRIPTION
Small fix that adjust the documentation.

```
work@fedora:~/development/podman-ai-lab-to-rhoai$ ls -l ./notebooks/Langchain-ElasticSearchVector-ingest.ipynb
ls: cannot access './notebooks/Langchain-ElasticSearchVector-ingest.ipynb': No such file or directory

work@fedora:~/development/podman-ai-lab-to-rhoai$ ls -l ./notebooks/Langchain-ElasticSearchVector-Ingest.ipynb
-rw-r--r--. 1 work work 28936 Aug 14 07:36 ./notebooks/Langchain-ElasticSearchVector-Ingest.ipynb

```